### PR TITLE
Add quotes to chmod command

### DIFF
--- a/vars/gitAskPass.groovy
+++ b/vars/gitAskPass.groovy
@@ -5,7 +5,7 @@ def call(credentialsId, gitCommand) {
     writeFile(file: tmpAskPassScript, text: askPassScript)
     withCredentials([usernamePassword(credentialsId: credentialsId, passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME')]) {            
         sh """
-        chmod +x ${tmpAskPassScript}
+        chmod +x \"${tmpAskPassScript}\"
         GIT_ASKPASS=${tmpAskPassScript} ${gitCommand}
         """
     }


### PR DESCRIPTION
The job name or any of its parent folders may contain whitespace